### PR TITLE
feat: automatically generate code prompt files

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "reload": "npm run build && pm2 reload api-server --parallel 32 --update-env",
     "api:download": "node packages/scripts/download.js",
     "api:docs": "git checkout main && git pull && node packages/scripts/index.js",
-    "api:vscode": "git checkout main && git pull && node packages/scripts/vscode"
+    "api:vscode": "git checkout main && git pull && node packages/scripts/vscode",
+    "api:helper": "git checkout main && git pull && node packages/scripts/helper"
   },
   "author": "TDesign",
   "license": "ISC"

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -60,3 +60,13 @@ npm run api:docs Button 'Vue(PC)' useDefault,finalProject,onlyDocs,isUseUnitTest
 npm run api:vscode 'Vue(PC)'
 npm run api:vscode 'React(PC)'
 ```
+
+## npm run api:helper
+
+自动生成代码提示文件
+
+```bash
+npm run api:helper 'Vue(PC)'
+npm run api:helper 'VueNext(PC)'
+npm run api:helper 'Vue(Mobile)'
+```

--- a/packages/scripts/common.js
+++ b/packages/scripts/common.js
@@ -27,6 +27,10 @@ function isTypeApi(cmp) {
   return componentsMap[cmp] && componentsMap[cmp].type === 'TS';
 }
 
+function isComponent(cmp) {
+  return !componentsMap[cmp].type;
+}
+
 function getCmpName(cmp) {
   if (isPlugin(cmp)) return renameToCase(cmp);
   if (isTypeApi(cmp)) {
@@ -175,6 +179,8 @@ module.exports = {
   renameToCase,
   isPlugin,
   isTypeApi,
+  isComponent,
+  componentsMap,
   getTdCmpName,
   getEventName,
   getFolderName,

--- a/packages/scripts/config/index.js
+++ b/packages/scripts/config/index.js
@@ -40,6 +40,9 @@ const FRAMEWORK_MAP = {
     getDocs: getVueApiDocs,
     titleMap: VUE_TITILE_MAP,
     vscodePath: `${BASE_PATH_URL}/vscode-tdesign/document/vue2`,
+    helperPath: `${BASE_PATH_URL}/tdesign-vue/helper`,
+    docsPath: 'https://tdesign.tencent.com/vue/components/',
+    name: 'tdesign-vue',
     TNode,
   },
   'VueNext(PC)': {
@@ -60,6 +63,9 @@ const FRAMEWORK_MAP = {
     getDocs: getVueApiDocs,
     titleMap: VUE_TITILE_MAP,
     vscodePath: `${BASE_PATH_URL}/vscode-tdesign/document/vue3`,
+    helperPath: `${BASE_PATH_URL}/tdesign-vue-next/helper`,
+    docsPath: 'https://tdesign.tencent.com/vue-next/components/',
+    name: 'tdesign-vue-next',
     TNode,
   },
   'React(PC)': {
@@ -106,6 +112,9 @@ const FRAMEWORK_MAP = {
     getDocs: getVueApiDocs,
     titleMap: VUE_TITILE_MAP,
     vscodePath: `${BASE_PATH_URL}/vscode-tdesign/document/vue_mobile`,
+    helperPath: `${BASE_PATH_URL}/tdesign-mobile-vue/helper`,
+    docsPath: 'https://tdesign.tencent.com/mobile-vue/components/',
+    name: 'tdesign-mobile-vue',
     TNode,
   },
   'React(Mobile)': {

--- a/packages/scripts/helper/index.js
+++ b/packages/scripts/helper/index.js
@@ -1,0 +1,156 @@
+/**
+ * 1. 自动生成代码提示文件 web-types.json tags.json attributes.json
+ *
+ * 命名行示例：npm run api:helper 'Vue(PC)'
+ * 命名行示例：npm run api:helper 'VueNext(PC)'
+ * 命名行示例：npm run api:helper 'Vue(Mobile)'
+ *
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { groupByComponent, formatArrayToMap, isComponent, componentsMap } = require('../common');
+const map = require('../map.json');
+const { data: ALL_API } = require('../api.json');
+const { FRAMEWORK_MAP } = require('../config');
+const kebabCase = require('lodash/kebabCase');
+const chalk = require('chalk');
+ /**
+  * framework 参数可选值：Vue(PC)/VueNext(PC)/Vue(Mobile)
+  */
+const [framework] = process.argv.slice(2);
+ 
+start();
+ 
+function start() {
+  if (!['Vue(PC)', 'VueNext(PC)', 'Vue(Mobile)'].includes(framework)) {
+    return console.log(chalk.blue(`不支持向当前框架生成代码提示文件（框架：${framework}）`));
+  }
+  console.log(chalk.blue(`\n ----- 代码提示文件相关文件自动生成开始（框架：${framework}） ------ \n`));
+  // [ labe, value ] => { label: value }
+  const frameworkMap = formatArrayToMap(map.data, 'platform_framework');
+  const framworkData = groupByComponent(ALL_API, frameworkMap[framework]);
+  // 生成代码提示文件
+  generateHelper(framworkData, framework);
+}
+
+function generateHelper(baseData, framework) {
+  const { webTypes, tags, attributes } = getHelperData(baseData, framework);
+
+  write(framework, 'tags.json', tags);
+  write(framework, 'attributes.json', attributes);
+  write(framework, 'web-types.json', webTypes);
+}
+
+function getHelperData(baseData, framework) {
+  const current = FRAMEWORK_MAP[framework];
+  const tags = {};
+  const attributes = {};
+  const vueComponents = [];
+
+  for (const key in baseData) {
+    if (!isComponent(key)) {
+      continue;
+    }
+    const componentName = `t-${kebabCase(key)}`;
+    const props = [];
+    const propsList = [];
+    const eventsList = [];
+    const componentDocs = `${current.docsPath}${kebabCase(key)}`;
+    const description = `${componentsMap[key].value}\n\n${componentsMap[key].label}`;
+
+    for (let i = 0; i < baseData[key].length; i++) {
+      const api = baseData[key][i];
+      if (/（暂未实现）/.test(api.field_name)) {
+        continue;
+      }
+
+      const prop = kebabCase(api.field_name);
+      const attributeKey = `${componentName}/${prop}`;
+      const apiDocs = `${componentDocs}?tab=api#${key.toLowerCase()}`;
+      const apiDescription = `${api.field_desc_en ? `${api.field_desc_en}\n\n` : ''}${api.field_desc_zh || ''}`;
+
+      switch (api.field_category_text) {
+        case 'Props':
+          props.push(prop);
+          attributes[attributeKey] = {
+            type: api.field_type_text.join('|') || undefined,
+            options: api.field_enum ? api.field_enum.split('/') : undefined,
+            description: `${apiDescription}\n\n${api.field_default_value ? `default: ${api.field_default_value}\n\n` : ''}[docs](${apiDocs}-props)`,
+          }
+          propsList.push({
+            name: prop,
+            description: apiDescription,
+            'doc-url': `${apiDocs}-props`,
+            type: api.field_type_text,
+            default: api.field_default_value || undefined,
+            'attribute-value': api.field_enum
+              ? { type: /^string$/i.test(api.field_type_text.join('')) ? 'enum' : 'of-match' }
+              : undefined,
+            values: api.field_enum ? api.field_enum.split('/').map(name => ({ name })) : undefined,
+          })
+          break;
+        case 'Events':
+          props.push(prop);
+          attributes[attributeKey] = {
+            type: 'event',
+            description: `${apiDescription}\n\n[docs](${apiDocs}-events)`,
+          }
+          eventsList.push({
+            name: prop,
+            description: apiDescription,
+            'doc-url': `${apiDocs}-events`,
+          })
+          break
+        default:
+          break;
+      }
+    }
+
+    tags[componentName] = {
+      attributes: props,
+      description: `${description}\n\n[docs](${componentDocs})`
+    }
+    vueComponents.push({
+      name: componentName,
+      source: { symbol: key },
+      description,
+      'doc-url': componentDocs,
+      props: propsList,
+      js: eventsList.length ? { events: eventsList } : undefined,
+    })
+  }
+
+  return {
+    tags,
+    attributes,
+    webTypes: {
+      $schema: 'http://json.schemastore.org/web-types',
+      framework: 'vue',
+      name: current.name,
+      'js-types-syntax': 'typescript',
+      'description-markup': 'markdown',
+      contributions: {
+        html: {
+          'vue-components': vueComponents,
+        },
+      },
+    }
+  }
+}
+
+function write(framework, name, data) {
+  const current = FRAMEWORK_MAP[framework];
+  const fileName = path.resolve(current.helperPath, name);
+  const buffer = JSON.stringify(data, null, 2);
+
+  writeFileRecursive(fileName, buffer);
+}
+
+function writeFileRecursive(name, buffer) {
+  const lastPath = name.substring(0, name.lastIndexOf('/'));
+
+  fs.mkdir(lastPath, { recursive: true }, () => {
+    fs.writeFileSync(name, buffer);
+  });
+}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "api:download": "node ./download.js",
     "api:docs": "npm run api:download && node ./index.js",
-    "api:vscode": "npm run api:download && node ./vscode"
+    "api:vscode": "npm run api:download && node ./vscode",
+    "api:helper": "npm run api:download && node ./helper"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
close #51

解析 api.json 内容为 Vue 生成代码提示文件

## 接下来

需要向 Vue(PC)、VueNext(PC)、Vue(Mobile) 提交生成文件，同时向 package.json 增加

```diff
"files": [
+    "helper",
  ],
+ "vetur": {
+    "tags": "helper/tags.json",
+    "attributes": "helper/attributes.json"
+  },
+  "web-types": "helper/web-types.json",
```

确保代码提示文件一同发布到npm

`helper`- 生成代码提示文件目录，通过 helperPath 修改