### PR TITLE
chore: unified name

### DIFF
--- a/packages/scripts/docs/index.js
+++ b/packages/scripts/docs/index.js
@@ -64,7 +64,7 @@ function outputComponentMD(file, apiData, isVscode) {
       : `${data}\n${SIGNATURE}\n${apiData}`;
     result = result.replace('\n:: BASE_PROPS ::\n', '');
     if (cssVariables) {
-      result += `\n### CSS 变量\n\n${cssVariables.trim()}`;
+      result += `\n### CSS Variables\n\n${cssVariables.trim()}`;
     }
     fs.writeFile(file, result, 'utf8', (err) => {
       if (err) return console.error(err);


### PR DESCRIPTION
- 中文/英文文档统一使用 `CSS Variables` 作为 css 变量模块标题，与外部样式类模块保持一致

<img width="1426" alt="截屏2024-05-06 15 32 35" src="https://github.com/TDesignOteam/tdesign-api/assets/51158141/80973ff6-925d-4ae7-8592-7576ccb0d928">
<img width="1443" alt="截屏2024-05-06 15 32 17" src="https://github.com/TDesignOteam/tdesign-api/assets/51158141/d0a96b6f-fef0-4b8f-8df8-70549f71ac36">
