### PR TITLE
[ColorPicker] Update API for input-less trigger

### DIFF
--- a/packages/products/tdesign-vue-next/packages/components/color-picker/color-picker.en-US.md
+++ b/packages/products/tdesign-vue-next/packages/components/color-picker/color-picker.en-US.md
@@ -14,6 +14,7 @@ enableAlpha | Boolean | false | \- | N
 enableMultipleGradient | Boolean | true | \- | N
 format | String | RGB | When `enableAlpha` is true, `HEX8/RGBA/HSLA/HSVA` are valid。options: HEX/HEX8/RGB/RGBA/HSL/HSLA/HSV/HSVA/CMYK/CSS | N
 inputProps | Object | - | Typescript：`InputProps`，[Input API Documents](./input?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
+isInput | Boolean | true | Whether to display the color value input. When false, only the color swatch is displayed. | N
 popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
 recentColors | Array | [] | used color recently。`v-model:recentColors` is supported。Typescript：`Array<string> \| boolean \| null` | N
 defaultRecentColors | Array | [] | used color recently。uncontrolled property。Typescript：`Array<string> \| boolean \| null` | N

--- a/packages/products/tdesign-vue-next/packages/components/color-picker/color-picker.md
+++ b/packages/products/tdesign-vue-next/packages/components/color-picker/color-picker.md
@@ -14,6 +14,7 @@ enableAlpha | Boolean | false | 是否开启透明通道 | N
 enableMultipleGradient | Boolean | true | 是否允许开启通过点击渐变轴增加渐变梯度，默认开启，关闭时只会存在起始和结束两个颜色 | N
 format | String | RGB | 格式化色值。`enableAlpha` 为真时，`HEX8/RGBA/HSLA/HSVA` 有效。可选项：HEX/HEX8/RGB/RGBA/HSL/HSLA/HSV/HSVA/CMYK/CSS | N
 inputProps | Object | - | 透传 Input 输入框组件全部属性。TS 类型：`InputProps`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
+isInput | Boolean | true | 是否显示颜色值输入框，值为 false 时仅显示颜色色块 | N
 popupProps | Object | - | 透传 Popup 组件全部属性，如 `placement` `overlayStyle` `overlayClassName` `trigger`等。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
 recentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 false 或 null 则完全不显示“最近使用颜色”。支持语法糖 `v-model:recentColors`。TS 类型：`Array<string> \| boolean \| null` | N
 defaultRecentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 false 或 null 则完全不显示“最近使用颜色”。非受控属性。TS 类型：`Array<string> \| boolean \| null` | N

--- a/packages/products/tdesign-vue-next/packages/components/color-picker/props.ts
+++ b/packages/products/tdesign-vue-next/packages/components/color-picker/props.ts
@@ -15,7 +15,7 @@ export default {
   /** 颜色模式选择。同时支持单色和渐变两种模式，可仅使用单色或者渐变其中一种模式，也可以同时使用。`monochrome` 表示单色，`linear-gradient` 表示渐变色 */
   colorModes: {
     type: Array as PropType<TdColorPickerProps['colorModes']>,
-    default: (): TdColorPickerProps['colorModes'] => ["monochrome", "linear-gradient"],
+    default: (): TdColorPickerProps['colorModes'] => ['monochrome', 'linear-gradient'],
   },
   /** 是否禁用组件 */
   disabled: {
@@ -41,6 +41,11 @@ export default {
   /** 透传 Input 输入框组件全部属性 */
   inputProps: {
     type: Object as PropType<TdColorPickerProps['inputProps']>,
+  },
+  /** 是否显示颜色值输入框，值为 false 时仅显示颜色色块 */
+  isInput: {
+    type: Boolean,
+    default: true,
   },
   /** 透传 Popup 组件全部属性，如 `placement` `overlayStyle` `overlayClassName` `trigger`等 */
   popupProps: {

--- a/packages/products/tdesign-vue-next/packages/components/color-picker/type.ts
+++ b/packages/products/tdesign-vue-next/packages/components/color-picker/type.ts
@@ -49,6 +49,11 @@ export interface TdColorPickerProps {
    */
   inputProps?: InputProps;
   /**
+   * 是否显示颜色值输入框，值为 false 时仅显示颜色色块
+   * @default true
+   */
+  isInput?: boolean;
+  /**
    * 透传 Popup 组件全部属性，如 `placement` `overlayStyle` `overlayClassName` `trigger`等
    */
   popupProps?: PopupProps;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
                                                                                            
  - [ ] 日常 bug 修复                                                                       
  - [x] 新特性提交                                                                          
  - [x] 文档改进                                                                            
  - [ ] 演示代码改进                                                                        
  - [ ] 组件样式/交互改进
  - [ ] CI/CD 改进                                                                          
  - [ ] 重构                                                                                
  - [ ] 代码风格优化                                                                        
  - [ ] 测试用例                                                                            
  - [ ] 分支合并                                                                            
  - [ ] 其他                                                                                
                                                                                            
  ### 🔗 相关 Issue                                                                         
                                                                                            
  close Tencent/tdesign-common#2567                                                         
                                                                                            
  ### 💡 需求背景和解决方案                                                                 
                                                                                            
  ColorPicker 需要支持只展示颜色色块、不展示色值输入框的触发器形态。该能力由组件侧新增      
  `isInput` API 承载，默认保持现有输入框触发器行为。                                        
                                                                                            
  本次在 `tdesign-api` 中补充 ColorPicker 的 API 元数据，并同步生成 Vue Next 产物：         
                                                                                            
  - 新增 `isInput` API                                                                      
  - 类型为 `boolean`                                                                        
  - 默认值为 `true`                                                                         
  - 当值为 `false` 时，仅展示颜色色块，不展示颜色值输入框                                   
  - 同步更新 Vue Next 的 `type.ts`、`props.ts` 和中英文 API 文档生成结果                    
                                                                                            
  用法示例：                                                                                
                                                                                            
  ```vue                                                                                    
  <t-color-picker v-model="color" :is-input="false" />                                      
                                                                                            
  ### 📝 更新日志                                                                           
                                                                                            
  - feat(ColorPicker): add isInput API metadata                                             
  - [ ] 本条 PR 不需要纳入 Changelog                                                        
                                                                                            
  ### 请求合并前的自查清单                                                                  
                                                                                            
  - [x] 文档已补充或无须补充                                                                
  - [ ] 代码演示已提供或无须提供                                                            
  - [x] TypeScript 定义已补充或无须补充                                                     
  - [x] Changelog 已提供或无须提供                                                          
                                         