### PR TITLE
fix(ci): repair spell-check workflow reference

### DIFF
--- a/.github/workflows/pr-spell-check.yml
+++ b/.github/workflows/pr-spell-check.yml
@@ -3,6 +3,6 @@ on: [pull_request]
 
 jobs:
     call-spell-check:
-        uses: TDesignOteam/workflows/.github/workflows/reusable-spell-check.yml@4e2d1063b106761c54bf9bf58a7502f9017c4b4b # main
+        uses: TDesignOteam/workflows/.github/workflows/reusable-spell-check.yml@main
         with:
             config: .github/workflows/typos-config.toml

--- a/.github/workflows/pr-spell-check.yml
+++ b/.github/workflows/pr-spell-check.yml
@@ -3,6 +3,6 @@ on: [pull_request]
 
 jobs:
     call-spell-check:
-        uses: TDesignOteam/workflows/.github/workflows/reusable-spell-check.yml@@main
+        uses: TDesignOteam/workflows/.github/workflows/reusable-spell-check.yml@4e2d1063b106761c54bf9bf58a7502f9017c4b4b # main
         with:
             config: .github/workflows/typos-config.toml


### PR DESCRIPTION
## Summary

- fix the malformed reusable workflow reference introduced in #936
- pin the reusable spell-check workflow to the current workflows/main commit
- restore job creation for the pr-spell-check workflow

## Root cause

The workflow reference contained two at signs before main, so GitHub rejected the workflow before creating any jobs.

## Validation

- parsed pr-spell-check.yml with js-yaml
- confirmed reusable-spell-check.yml exists at the pinned commit
- confirmed the reusable workflow declares the config input
- git diff --check